### PR TITLE
Fixing bad tag in canal-etcdless

### DIFF
--- a/k8s-install/canal-etcdless.yaml
+++ b/k8s-install/canal-etcdless.yaml
@@ -125,7 +125,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel-git:v0.7.0
+          image: quay.io/coreos/flannel:v0.7.0
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true


### PR DESCRIPTION
Flannel tag still had flannel-git in it.  Fixes #34 