### PR TITLE
Updating manifests

### DIFF
--- a/k8s-install/1.6/canal.yaml
+++ b/k8s-install/1.6/canal.yaml
@@ -23,6 +23,7 @@ data:
         "type": "calico",
         "log_level": "info",
         "datastore_type": "kubernetes",
+        "hostname": "__KUBERNETES_NODE_NAME__",
         "ipam": {
             "type": "host-local",
             "subnet": "usePodCidr"
@@ -46,7 +47,6 @@ data:
       }
     }
 
-
 ---
 
 # This manifest installs the calico/node container, as well
@@ -69,17 +69,23 @@ spec:
         k8s-app: canal
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
+      serviceAccountName: canal
+      tolerations:
+        # Allow the pod to run on the master.  This is required for
+        # the master to communicate with pods.
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v1.0.1
+          image: quay.io/calico/node:v1.1.3
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -87,15 +93,27 @@ spec:
             # Enable felix logging.
             - name: FELIX_LOGSEVERITYSYS
               value: "info"
+            # Period, in seconds, at which felix re-applies all iptables state 
+            - name: FELIX_IPTABLESREFRESHINTERVAL
+              value: "60"
+            # Disable IPV6 support in Felix.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
             # Don't enable BGP.
             - name: CALICO_NETWORKING_BACKEND
               value: "none"
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
             # No IP address needed.
             - name: IP
               value: ""
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
@@ -114,7 +132,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v1.5.5
+          image: quay.io/calico/cni:v1.7.0
           command: ["/install-cni.sh"]
           env:
             # The CNI network config to install on each node.
@@ -123,6 +141,10 @@ spec:
                 configMapKeyRef:
                   name: canal-config
                   key: cni_network_config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir
@@ -131,29 +153,29 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.7.0
+          image: quay.io/coreos/flannel:v0.7.1
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true
           env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: FLANNELD_IFACE
-            valueFrom:
-              configMapKeyRef:
-                name: canal-config
-                key: canal_iface
-          - name: FLANNELD_IP_MASQ
-            valueFrom:
-              configMapKeyRef:
-                name: canal-config
-                key: masquerade
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: FLANNELD_IFACE
+              valueFrom:
+                configMapKeyRef:
+                  name: canal-config
+                  key: canal_iface
+            - name: FLANNELD_IP_MASQ
+              valueFrom:
+                configMapKeyRef:
+                  name: canal-config
+                  key: masquerade
           volumeMounts:
           - name: run
             mountPath: /run
@@ -181,3 +203,11 @@ spec:
         - name: flannel-cfg
           configMap:
             name: canal-config
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: canal
+  namespace: kube-system

--- a/k8s-install/1.6/rbac.yaml
+++ b/k8s-install/1.6/rbac.yaml
@@ -1,0 +1,126 @@
+# Calico Roles
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: canal
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - update
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups: ["extensions"]
+    resources:
+      - thirdpartyresources
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups: ["extensions"]
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["projectcalico.org"]
+    resources:
+      - globalconfigs
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups: ["projectcalico.org"]
+    resources:
+      - ippools
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+
+---
+
+# Flannel roles
+# Pulled from https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel-rbac.yml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flannel
+subjects:
+- kind: ServiceAccount
+  name: canal
+  namespace: kube-system
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: canal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: canal
+subjects:
+- kind: ServiceAccount
+  name: canal
+  namespace: kube-system

--- a/k8s-install/README.md
+++ b/k8s-install/README.md
@@ -1,9 +1,17 @@
 # Kubernetes self-hosted install
 
-Installation is simple:
+Installation is simple, for Kubernetes 1.5:
 
 ```
-kubectl apply -f canal.yaml
+kubectl apply -f https://raw.githubusercontent.com/projectcalico/canal/master/k8s-install/canal.yaml
+```
+
+For Kubernetes 1.6:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/projectcalico/canal/master/k8s-install/1.6/rbac.yaml
+
+kubectl apply -f https://raw.githubusercontent.com/projectcalico/canal/master/k8s-install/1.6/canal.yaml
 ```
 
 This directory includes two manifests for deploying canal on Kubernetes - one that requires its own etcd and one
@@ -23,9 +31,9 @@ configuring the install.
 Requirements:
 - Make sure you configure canal.yaml with the endpoints of your etcd cluster. 
 
-#### Without an etcd datastore (experimental) 
+#### Without an etcd datastore
 
-`canal-etcdless.yaml`: Contains a Kubernetes DaemonSet to install canal on each Kubernetes master and node.  This is an experimental mode which does not require access to an etcd cluster.
+`canal-kubernetes-datastore.yaml`: Contains a Kubernetes DaemonSet to install canal on each Kubernetes master and node.
 
 Requirements:
 - Make sure your controller manager has been started with `--cluster-cidr=10.244.0.0/16` and `--allocate-node-cidrs=true`.
@@ -36,7 +44,7 @@ Requirements:
 
 Canal uses the Kubernetes API to enforce policy, and so needs to authenticate with the Kubernetes API.  The provided
 ConfigMap [configures the Calico CNI plugin](https://github.com/projectcalico/calico-cni/blob/master/configuration.md#kubernetes-specific)
-automatically to use serviceaccount token authentication and the Kubernetes Service clusterIP. 
+automatically to use service account token authentication and the Kubernetes Service clusterIP. 
 
 ### Etcd
 

--- a/k8s-install/canal-kubernetes-datastore.yaml
+++ b/k8s-install/canal-kubernetes-datastore.yaml
@@ -1,0 +1,200 @@
+# This ConfigMap can be used to configure a self-hosted Canal installation.
+# See `canal.yaml` for an example of a Canal deployment which uses
+# the config in this ConfigMap.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: canal-config
+  namespace: kube-system
+data:
+  # The interface used by canal for host <-> host communication.
+  # If left blank, then the interface is chosing using the node's
+  # default route.
+  canal_iface: ""
+
+  # Whether or not to masquerade traffic to destinations not within
+  # the pod network.
+  masquerade: "true"
+
+  # The CNI network configuration to install on each node.
+  cni_network_config: |-
+    {
+        "name": "k8s-pod-network",
+        "type": "calico",
+        "log_level": "info",
+        "datastore_type": "kubernetes",
+        "hostname": "__KUBERNETES_NODE_NAME__",
+        "ipam": {
+            "type": "host-local",
+            "subnet": "usePodCidr"
+        },
+        "policy": {
+            "type": "k8s",
+            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+        },
+        "kubernetes": {
+            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+            "kubeconfig": "__KUBECONFIG_FILEPATH__"
+        }
+    }
+
+  # Flannel network configuration.
+  net-conf.json: |
+    {
+      "Network": "10.244.0.0/16",
+      "Backend": {
+        "Type": "vxlan"
+      }
+    }
+
+
+---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: canal
+  namespace: kube-system
+  labels:
+    k8s-app: canal
+spec:
+  selector:
+    matchLabels:
+      k8s-app: canal
+  template:
+    metadata:
+      labels:
+        k8s-app: canal
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key": "CriticalAddonsOnly", "operator": "Exists"}]
+    spec:
+      hostNetwork: true
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: quay.io/calico/node:v1.1.3
+          env:
+            # Use Kubernetes API as the backing datastore.
+            - name: DATASTORE_TYPE
+              value: "kubernetes"
+            # Enable felix logging.
+            - name: FELIX_LOGSEVERITYSYS
+              value: "info"
+            # Period, in seconds, at which felix re-applies all iptables state
+            - name: FELIX_IPTABLESREFRESHINTERVAL
+              value: "60"
+            # Disable IPV6 support in Felix.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Don't enable BGP.
+            - name: CALICO_NETWORKING_BACKEND
+              value: "none"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            # No IP address needed.
+            - name: IP
+              value: ""
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: quay.io/calico/cni:v1.7.0
+          command: ["/install-cni.sh"]
+          env:
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: canal-config
+                  key: cni_network_config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+        # This container runs flannel using the kube-subnet-mgr backend
+        # for allocating subnets.
+        - name: kube-flannel
+          image: quay.io/coreos/flannel:v0.7.1
+          command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
+          securityContext:
+            privileged: true
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: FLANNELD_IFACE
+              valueFrom:
+                configMapKeyRef:
+                  name: canal-config
+                  key: canal_iface
+            - name: FLANNELD_IP_MASQ
+              valueFrom:
+                configMapKeyRef:
+                  name: canal-config
+                  key: masquerade
+          volumeMounts:
+          - name: run
+            mountPath: /run
+          - name: flannel-cfg
+            mountPath: /etc/kube-flannel/
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+        # Used by flannel.
+        - name: run
+          hostPath:
+            path: /run
+        - name: flannel-cfg
+          configMap:
+            name: canal-config

--- a/k8s-install/canal.yaml
+++ b/k8s-install/canal.yaml
@@ -60,7 +60,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
           [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+           {"key": "CriticalAddonsOnly", "operator": "Exists"}]
       labels:
         k8s-app: canal-node
     spec:
@@ -69,7 +69,7 @@ spec:
         # Runs the flannel daemon to enable vxlan networking between
         # container hosts.
         - name: flannel
-          image: quay.io/coreos/flannel:v0.7.0
+          image: quay.io/coreos/flannel:v0.7.1
           env:
             # The location of the etcd cluster.
             - name: FLANNELD_ETCD_ENDPOINTS
@@ -103,7 +103,7 @@ spec:
         # container programs network policy and local routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v1.0.1
+          image: quay.io/calico/node:v1.1.3
           env:
             # The location of the etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -132,7 +132,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-calico-cni
-          image: quay.io/calico/cni:v1.5.5
+          image: quay.io/calico/cni:v1.7.0
           imagePullPolicy: Always
           command: ["/install-cni.sh"]
           env:
@@ -240,7 +240,7 @@ spec:
       hostNetwork: true
       containers:
         - name: calico-policy-controller
-          image: quay.io/calico/kube-policy-controller:v0.5.2
+          image: quay.io/calico/kube-policy-controller:v0.5.4
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS

--- a/k8s-install/canal_etcd_tls.yml
+++ b/k8s-install/canal_etcd_tls.yml
@@ -87,7 +87,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
           [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+           {"key": "CriticalAddonsOnly", "operator": "Exists"}]
       labels:
         k8s-app: canal-node
     spec:
@@ -96,7 +96,7 @@ spec:
         # Runs the flannel daemon to enable vxlan networking between
         # container hosts.
         - name: flannel
-          image: quay.io/coreos/flannel:v0.7.0
+          image: quay.io/coreos/flannel:v0.7.1
           env:
             # The location of the etcd cluster.
             - name: FLANNELD_ETCD_ENDPOINTS
@@ -168,7 +168,7 @@ spec:
         # container programs network policy and local routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v1.1.0
+          image: quay.io/calico/node:v1.1.3
           env:
             # The location of the etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -217,7 +217,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-calico-cni
-          image: quay.io/calico/cni:v1.5.5
+          image: quay.io/calico/cni:v1.7.0
           imagePullPolicy: Always
           command: ["/install-cni.sh"]
           env:

--- a/k8s-install/kubeadm/1.6/canal.yaml
+++ b/k8s-install/kubeadm/1.6/canal.yaml
@@ -136,7 +136,7 @@ spec:
         # Runs the flannel daemon to enable vxlan networking between
         # container hosts.
         - name: flannel
-          image: quay.io/coreos/flannel:v0.7.0
+          image: quay.io/coreos/flannel:v0.7.1
           env:
             # The location of the etcd cluster.
             - name: FLANNELD_ETCD_ENDPOINTS
@@ -170,7 +170,7 @@ spec:
         # container programs network policy and local routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v1.1.0
+          image: quay.io/calico/node:v1.1.3
           env:
             # The location of the etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -202,7 +202,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-calico-cni
-          image: quay.io/calico/cni:v1.6.2
+          image: quay.io/calico/cni:v1.7.0
           imagePullPolicy: Always
           command: ["/install-cni.sh"]
           env:

--- a/k8s-install/kubeadm/README.md
+++ b/k8s-install/kubeadm/README.md
@@ -27,4 +27,6 @@ node on the Kubernetes master.  Note that in a production cluster, it is recomme
 ### Requirements / Limitations
 
 * This install does not configure etcd TLS
-* This install expects that your Kubernetes master node has been labeled with `kubeadm.alpha.kubernetes.io/role: master`
+* This install expects that your Kubernetes master node has been labeled with:
+  * Kubernetes 1.5: `kubeadm.alpha.kubernetes.io/role: master`
+  * Kubernetes 1.6: `node-role.kubernetes.io/master`

--- a/k8s-install/kubeadm/canal.yaml
+++ b/k8s-install/kubeadm/canal.yaml
@@ -162,7 +162,7 @@ spec:
         # container programs network policy and local routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v1.1.0
+          image: quay.io/calico/node:v1.1.3
           env:
             # The location of the etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -194,7 +194,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-calico-cni
-          image: quay.io/calico/cni:v1.6.2
+          image: quay.io/calico/cni:v1.7.0
           imagePullPolicy: Always
           command: ["/install-cni.sh"]
           env:
@@ -257,7 +257,7 @@ spec:
     metadata:
       name: configure-canal
       annotations:
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated", "operator":"Exists"}]'
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key": "dedicated", "operator": "Exists"}]'
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostNetwork: true
@@ -297,7 +297,7 @@ spec:
   template:
     metadata:
       annotations:
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated", "operator":"Exists"}]'
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key": "dedicated", "operator": "Exists"}]'
         scheduler.alpha.kubernetes.io/critical-pod: ''
       name: calico-policy-controller
       namespace: kube-system


### PR DESCRIPTION
- Upgraded versions
  - calico/node to v1.1.3
  - policy-controller to v0.5.4
  - install-cni to 1.7.0
- Updated etcdless to -kubernetes-datastore
- updated canal-kubernetes-datastore as it was missing some env vars
- Updated Readme
  - removed `experimental` tags and renamed etcdless to kubernetes-datastore

Fixes #56 
Fixes #57 