### PR TITLE
Adding hostport config to all canal manifests

### DIFF
--- a/k8s-install/1.6/canal.yaml
+++ b/k8s-install/1.6/canal.yaml
@@ -18,22 +18,32 @@ data:
   cni_network_config: |-
     {
         "name": "k8s-pod-network",
-        "type": "calico",
-        "log_level": "info",
-        "datastore_type": "kubernetes",
-        "nodename": "__KUBERNETES_NODE_NAME__",
-        "ipam": {
-            "type": "host-local",
-            "subnet": "usePodCidr"
-        },
-        "policy": {
-            "type": "k8s",
-            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-        },
-        "kubernetes": {
-            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-            "kubeconfig": "__KUBECONFIG_FILEPATH__"
-        }
+        "cniVersion": "0.3.0",
+        "plugins": [
+            {
+                "type": "calico",
+                "log_level": "info",
+                "datastore_type": "kubernetes",
+                "nodename": "__KUBERNETES_NODE_NAME__",
+                "ipam": {
+                    "type": "host-local",
+                    "subnet": "usePodCidr"
+                },
+                "policy": {
+                    "type": "k8s",
+                    "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+                },
+                "kubernetes": {
+                    "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+                    "kubeconfig": "__KUBECONFIG_FILEPATH__"
+                }
+            },
+            {
+                "type": "portmap",
+                "capabilities": {"portMappings": true},
+                "snat": true
+            }
+        ]
     }
 
   # Flannel network configuration. Mounted into the flannel container.
@@ -136,6 +146,8 @@ spec:
           image: quay.io/calico/cni:v1.10.0
           command: ["/install-cni.sh"]
           env:
+            - name: CNI_CONF_NAME
+              value: "10-calico.conflist"
             # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG
               valueFrom:

--- a/k8s-install/1.7/canal.yaml
+++ b/k8s-install/1.7/canal.yaml
@@ -18,23 +18,32 @@ data:
   cni_network_config: |-
     {
         "name": "k8s-pod-network",
-        "cniVersion": "0.1.0",
-        "type": "calico",
-        "log_level": "info",
-        "datastore_type": "kubernetes",
-        "nodename": "__KUBERNETES_NODE_NAME__",
-        "ipam": {
-            "type": "host-local",
-            "subnet": "usePodCidr"
-        },
-        "policy": {
-            "type": "k8s",
-            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-        },
-        "kubernetes": {
-            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-            "kubeconfig": "__KUBECONFIG_FILEPATH__"
-        }
+        "cniVersion": "0.3.0",
+        "plugins": [
+            {
+                "type": "calico",
+                "log_level": "info",
+                "datastore_type": "kubernetes",
+                "nodename": "__KUBERNETES_NODE_NAME__",
+                "ipam": {
+                    "type": "host-local",
+                    "subnet": "usePodCidr"
+                },
+                "policy": {
+                    "type": "k8s",
+                    "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+                },
+                "kubernetes": {
+                    "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+                    "kubeconfig": "__KUBECONFIG_FILEPATH__"
+                }
+            },
+            {
+                "type": "portmap",
+                "capabilities": {"portMappings": true},
+                "snat": true
+            }
+        ]
     }
 
   # Flannel network configuration. Mounted into the flannel container.
@@ -152,6 +161,8 @@ spec:
           image: quay.io/calico/cni:v1.10.0
           command: ["/install-cni.sh"]
           env:
+            - name: CNI_CONF_NAME
+              value: "10-calico.conflist"
             # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG
               valueFrom:

--- a/k8s-install/canal.yaml
+++ b/k8s-install/canal.yaml
@@ -18,22 +18,32 @@ data:
   cni_network_config: |-
     {
         "name": "k8s-pod-network",
-        "type": "calico",
-        "log_level": "info",
-        "datastore_type": "kubernetes",
-        "nodename": "__KUBERNETES_NODE_NAME__",
-        "ipam": {
-            "type": "host-local",
-            "subnet": "usePodCidr"
-        },
-        "policy": {
-            "type": "k8s",
-            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-        },
-        "kubernetes": {
-            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-            "kubeconfig": "__KUBECONFIG_FILEPATH__"
-        }
+        "cniVersion": "0.3.0",
+        "plugins": [
+            {
+                "type": "calico",
+                "log_level": "info",
+                "datastore_type": "kubernetes",
+                "nodename": "__KUBERNETES_NODE_NAME__",
+                "ipam": {
+                    "type": "host-local",
+                    "subnet": "usePodCidr"
+                },
+                "policy": {
+                    "type": "k8s",
+                    "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+                },
+                "kubernetes": {
+                    "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+                    "kubeconfig": "__KUBECONFIG_FILEPATH__"
+                }
+            },
+            {
+                "type": "portmap",
+                "capabilities": {"portMappings": true},
+                "snat": true
+            }
+        ]
     }
 
   # Flannel network configuration. Mounted into the flannel container.
@@ -130,6 +140,8 @@ spec:
           image: quay.io/calico/cni:v1.10.0
           command: ["/install-cni.sh"]
           env:
+            - name: CNI_CONF_NAME
+              value: "10-calico.conflist"
             # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG
               valueFrom:

--- a/k8s-install/canal_etcd_tls.yaml
+++ b/k8s-install/canal_etcd_tls.yaml
@@ -22,23 +22,33 @@ data:
   cni_network_config: |-
     {
         "name": "canal",
-        "type": "flannel",
-        "delegate": {
-          "type": "calico",
-          "etcd_endpoints": "__ETCD_ENDPOINTS__",
-          "etcd_key_file": "__ETCD_KEY_FILE__",
-          "etcd_cert_file": "__ETCD_CERT_FILE__",
-          "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",
-          "log_level": "info",
-          "policy": {
-              "type": "k8s",
-              "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-              "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-          },
-          "kubernetes": {
-              "kubeconfig": "/etc/cni/net.d/__KUBECONFIG_FILENAME__"
-          }
-        }
+        "cniVersion": "0.3.0",
+        "plugins": [
+            {
+                "type": "flannel",
+                "delegate": {
+                    "type": "calico",
+                    "etcd_endpoints": "__ETCD_ENDPOINTS__",
+                    "etcd_key_file": "__ETCD_KEY_FILE__",
+                    "etcd_cert_file": "__ETCD_CERT_FILE__",
+                    "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",
+                    "log_level": "info",
+                    "policy": {
+                        "type": "k8s",
+                        "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+                        "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+                    },
+                    "kubernetes": {
+                        "kubeconfig": "/etc/cni/net.d/__KUBECONFIG_FILENAME__"
+                    }
+                }
+            },
+            {
+                "type": "portmap",
+                "capabilities": {"portMappings": true},
+                "snat": true
+            }
+        ]
     }
 
   # If you're using TLS enabled etcd uncomment the following.
@@ -227,7 +237,7 @@ spec:
           env:
             # The name of the CNI network config file to install.
             - name: CNI_CONF_NAME
-              value: "10-canal.conf"
+              value: "10-canal.conflist"
             # The location of the etcd cluster.
             - name: ETCD_ENDPOINTS
               valueFrom:


### PR DESCRIPTION
## Description
Fixes #102 

Updating Canal manifests to support hostport via portmap chaining.

I also noticed we're not on the latest Calico, I'd be happy to update and test that as well where it applies. We also were only changing the conf name in the `canal_etcd_tls.yaml` to `10-canal`, should we make them all the same?  I feel like `10-canal.conflist` would be a good name to standardize on for Canal.

## Todos
- [ ] Tests
- [ ] Documentation

