### PR TITLE
remove namespace from ClusterRoleBinding specs

### DIFF
--- a/k8s-install/1.6/rbac.yaml
+++ b/k8s-install/1.6/rbac.yaml
@@ -4,7 +4,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: calico
-  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources:

--- a/k8s-install/1.7/rbac.yaml
+++ b/k8s-install/1.7/rbac.yaml
@@ -4,7 +4,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: calico
-  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources:

--- a/k8s-install/canal_etcd_tls.yaml
+++ b/k8s-install/canal_etcd_tls.yaml
@@ -438,7 +438,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: canal
-  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources:


### PR DESCRIPTION
ClusterRoleBinding is not namespaced:
```
$ kubectl get clusterrolebindings --all-namespaces
NAMESPACE   NAME      AGE
error: clusterRoleBinding is not namespaced
```

It doesn't cause an error when using kubectl create - I'm guessing it just gets silently ignored, but...

I created a script to process these manifests and convert them to ansible code which posts to the API using the ansible uri module. The script chooses the API path to post to depending (amongst other things) on the presence of the namespace in the metadata. The clusterrolebindings in the canal manifests fail for this reason.