### PR TITLE
Switch deprecation notice to latest link

### DIFF
--- a/InstallGuide.md
+++ b/InstallGuide.md
@@ -1,6 +1,6 @@
-# [Canal manifests and docs](https://docs.projectcalico.org/v2.6/getting-started/kubernetes/installation/hosted/canal) have moved to [docs.projectcalico.org](https://docs.projectcalico.org/)
+# [Canal manifests and docs](https://docs.projectcalico.org/latest/getting-started/kubernetes/installation/hosted/canal) have moved to [docs.projectcalico.org](https://docs.projectcalico.org/)
 
-Refer to [Canal/flannel Hosted Install](https://docs.projectcalico.org/v2.6/getting-started/kubernetes/installation/hosted/canal)
+Refer to [Canal/flannel Hosted Install](https://docs.projectcalico.org/latest/getting-started/kubernetes/installation/hosted/canal)
 for up to date installation directions and manifests.
 This repo is deprecated and no further updates are expected here.
 

--- a/OrchestratorIntegration.md
+++ b/OrchestratorIntegration.md
@@ -1,6 +1,6 @@
-# [Canal manifests and docs](https://docs.projectcalico.org/v2.6/getting-started/kubernetes/installation/hosted/canal) have moved to [docs.projectcalico.org](https://docs.projectcalico.org/)
+# [Canal manifests and docs](https://docs.projectcalico.org/latest/getting-started/kubernetes/installation/hosted/canal) have moved to [docs.projectcalico.org](https://docs.projectcalico.org/)
 
-Refer to [Canal/flannel Hosted Install](https://docs.projectcalico.org/v2.6/getting-started/kubernetes/installation/hosted/canal)
+Refer to [Canal/flannel Hosted Install](https://docs.projectcalico.org/latest/getting-started/kubernetes/installation/hosted/canal)
 for up to date installation directions and manifests.
 This repo is deprecated and no further updates are expected here.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# [Canal manifests and docs](https://docs.projectcalico.org/v2.6/getting-started/kubernetes/installation/hosted/canal) have moved to [docs.projectcalico.org](https://docs.projectcalico.org/)
+# [Canal manifests and docs](https://docs.projectcalico.org/latest/getting-started/kubernetes/installation/hosted/canal) have moved to [docs.projectcalico.org](https://docs.projectcalico.org/)
 
-Refer to [Canal/flannel Hosted Install](https://docs.projectcalico.org/v2.6/getting-started/kubernetes/installation/hosted/canal)
+Refer to [Canal/flannel Hosted Install](https://docs.projectcalico.org/latest/getting-started/kubernetes/installation/hosted/canal)
 for up to date installation directions and manifests.
 This repo is deprecated and no further updates are expected here.
 

--- a/k8s-install/README.md
+++ b/k8s-install/README.md
@@ -1,6 +1,6 @@
-# [Canal manifests and docs](https://docs.projectcalico.org/v2.6/getting-started/kubernetes/installation/hosted/canal) have moved to [docs.projectcalico.org](https://docs.projectcalico.org/)
+# [Canal manifests and docs](https://docs.projectcalico.org/latest/getting-started/kubernetes/installation/hosted/canal) have moved to [docs.projectcalico.org](https://docs.projectcalico.org/)
 
-Refer to [Canal/flannel Hosted Install](https://docs.projectcalico.org/v2.6/getting-started/kubernetes/installation/hosted/canal)
+Refer to [Canal/flannel Hosted Install](https://docs.projectcalico.org/latest/getting-started/kubernetes/installation/hosted/canal)
 for up to date installation directions and manifests.
 This repo is deprecated and no further updates are expected here.
 


### PR DESCRIPTION
## Description
Switch the deprecation notice to use the 'latest' link so it will remain up-to-date.

## Todos
- [ ] Tests
- [ ] Documentation

