### PR TITLE
Fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# [Canal manifests and docs](https://docs.projectcalico.org/latest/getting-started/kubernetes/installation/flannel) have moved to [docs.projectcalico.org](https://docs.projectcalico.org/)
+# [Canal manifests and docs](https://docs.projectcalico.org/getting-started/kubernetes/flannel/flannel) have moved to [docs.projectcalico.org](https://docs.projectcalico.org/)
 
-Refer to [Canal/flannel Hosted Install](https://docs.projectcalico.org/latest/getting-started/kubernetes/installation/flannel)
-for up to date installation directions and manifests.
+Refer to the docs for [installing Calico for policy and flannel for networking](https://docs.projectcalico.org/getting-started/kubernetes/flannel/flannel) for up to date installation directions and manifests.
 This repo is deprecated and no further updates are expected here.
 
 ## Wasn't Canal supposed to be the new name for Calico?


### PR DESCRIPTION
Update the links directing users to the calico documentation